### PR TITLE
Ensure that other modules can still listen to storage.post

### DIFF
--- a/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -75,7 +75,7 @@ define(
                 }, function (err) {
                     // payloadExtender doesn't exist in 2.1, no problem
                     return $.when(payload);
-                }).done(function (pl) {
+                }).then(function (pl) {
                     fullScreenLoader.startLoader();
 
                     return storage.post(


### PR DESCRIPTION
When using .done, the result other modules get when adding a plugin to the default shipping-save-processor is the request, when the storage.post result is what is expected.

Changing this to .then means that other modules that are likely to add .done will receive the response as expected.

I have not tested if other modules can listen to .fail