### PR TITLE
Fix issue in OrderRepository plugin while placing order with virtual product via PayPal Express Checkout

### DIFF
--- a/Plugin/Sales/Model/OrderRepository.php
+++ b/Plugin/Sales/Model/OrderRepository.php
@@ -233,7 +233,8 @@ class OrderRepository
     private function isModuleEnabled(OrderInterface $order)
     {
         $storeId = $order->getStoreId();
-        $address = $order->getShippingAddress();
+        $isVirtual = $order->getIsVirtual();
+        $address = $isVirtual ? $order->getBillingAddress() : $order->getShippingAddress();
 
         return $this->config->isModuleEnabled($storeId)
             && $this->config->getTaxMode($storeId) != Config::TAX_MODE_NO_ESTIMATE_OR_SUBMIT


### PR DESCRIPTION
**Steps to reproduce**
1. Configure PayPal Express Checkout payment method with enabled feature "Display on Shopping Cart".
2. Add any virtual product to the Shopping Cart.
3. Click on "Check out with PayPal" button on Shopping Cart page.
4. Finish order after being redirected to PayPal.

**Expected result**
Order is placed without any issues.

**Actual result**
A 500 page is given after placing button "Place Order" on the review page.

---- 

**Technical details**
Here is related error log given:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to ClassyLlama\\AvaTax\\Helper\\Config::isAddressTaxable() must be an instance of Magento\\Framework\\DataObject, null given, called in <magento_root_dir>/vendor/avalara/avatax-magento/Plugin/Sales/Model/OrderRepository.php on line 240 and defined in <magento_root_dir>/vendor/avalara/avatax-magento/Helper/Config.php:405
Stack trace:
#0 <magento_root_dir>/vendor/avalara/avatax-magento/Plugin/Sales/Model/OrderRepository.php(240): ClassyLlama\\AvaTax\\Helper\\Config->isAddressTaxable(NULL, 1)
#1 <magento_root_dir>/vendor/avalara/avatax-magento/Plugin/Sales/Model/OrderRepository.php(90): ClassyLlama\\AvaTax\\Plugin\\Sales\\Model\\OrderRepository->isModuleEnabled(Object(Magento\\Sales\\Model\\Order\\Interceptor))
#2 <magento_root_dir>/vendor/avalara/avatax-magento/Plugin/Sales/Model/OrderRepository.php(65): ClassyLlama\\AvaTax\\Plugin\\Sal in <magento_root_dir>/vendor/avalara/avatax-magento/Helper/Config.php on line 405
```

The fix I've made is already is present in other places:
https://github.com/avadev/Avalara-AvaTax-for-Magento2/blob/master/Plugin/Sales/Model/Spi/CreditmemoResource.php#L112

https://github.com/avadev/Avalara-AvaTax-for-Magento2/blob/master/Plugin/Sales/Model/Spi/InvoiceResource.php#L112
