### PR TITLE
Fix issue with billing address automatically using shipping address 

### DIFF
--- a/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -59,7 +59,7 @@ define(
             module.saveShippingInformation = function () {
                 var payload;
 
-                if (!quote.billingAddress()) {
+                if (!quote.billingAddress() && quote.shippingAddress().canUseForBilling()) {
                     selectBillingAddressAction(quote.shippingAddress());
                 }
 


### PR DESCRIPTION
There is an issue where if `quote.shippingAddress().canUseForBilling()` is `false`, this module overrides Magento 2's default behaviour of showing the billing address form for users to input their data. It also causes issues with orders using the shipping address as the billing address regardless whether the user has entered a different billing address.