### PR TITLE
Required getIsVirtual check before access order shipping address

### DIFF
--- a/Plugin/Sales/Model/OrderRepository.php
+++ b/Plugin/Sales/Model/OrderRepository.php
@@ -233,7 +233,7 @@ class OrderRepository
     private function isModuleEnabled(OrderInterface $order)
     {
         $storeId = $order->getStoreId();
-        $address = $order->getShippingAddress();
+        $address = ($order->getIsVirtual()) ? $order->getBillingAddress() : $order->getShippingAddress();
 
         return $this->config->isModuleEnabled($storeId)
             && $this->config->getTaxMode($storeId) != Config::TAX_MODE_NO_ESTIMATE_OR_SUBMIT


### PR DESCRIPTION
This addresses a bug that can occur when a virtual order is taxed.  The Magento instance where I encountered this bug has a customized checkout, so I can't 100% guarantee the reproduction steps on a vanilla Magento install, but the issue is cut and dry, and the fix is ubiquitous.

IF an order has only virtual items in it, and tax rules are configured such that this order _does_ have taxes applied, then the following chain reaction occurs:

- In the final save of the order during the order placement process, `\ClassyLlama\AvaTax\Plugin\Sales\Model\OrderRepository::saveOrderTax` is called, and the main body of the method executes, since the order has tax and is currently being converted from the quote.
- This calls through to `isModuleEnabled` with the order object.
- `isModuleEnabled` attempts to pull an address from the order with `getShippingAddress`, then passes that result to `\ClassyLlama\AvaTax\Helper\Config::isAddressTaxable` without validating whether an address was returned.
- The typehinting of `isAddressTaxable` causes a fatal error with the null value.

The fix for this - making a check for `getIsVirtual` to determine whether it's appropriate to fetch the billing address or shipping address - is a pattern that is used throughout the module already (e.g., in `\ClassyLlama\AvaTax\Framework\Interaction\Tax::getCustomerCode`); this particular line of code was simply an oversight.  Ran this fix by @erikhansen ,  who oversaw the original development of this module.