### PR TITLE
build(deps): add support for Magento v2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "OSL-3.0",
     "description": "Magento module for Avalara's AvaTax suite of business tax calculation and processing services. Uses the AvaTax REST v2 API.",
     "require": {
-        "magento/framework": "^100.1.0|101.0.*|^102.0.0",
+        "magento/framework": "^100.1.0|101.0.*|^102.0.0|^103.0.0",
         "avalara/avatax": "^15.5.2.0"
     },
     "autoload": {


### PR DESCRIPTION
This bumps the allowed framework version to one installable by Magento v2.4. I don't know if this actually works, so please don't merge it yet. 

If you guys have a CI pipeline, you should likely run this through that first.