### PR TITLE
Update AvaTax.php

### DIFF
--- a/Ui/DataProvider/Product/Form/Modifier/AvaTax.php
+++ b/Ui/DataProvider/Product/Form/Modifier/AvaTax.php
@@ -48,6 +48,10 @@ class AvaTax extends AbstractModifier
      */
     public function modifyMeta(array $meta)
     {
+        if(!array_key_exists('avatax', $meta)){
+            return $meta;
+        }
+        
         $meta['avatax']['children']['container_avatax_cross_border_type']['children']['avatax_cross_border_type']['arguments']['data'] = [
             'options' => $this->crossBorderTypeFactory->create(),
             'config' => array_merge(


### PR DESCRIPTION
This function started throwing missing index exceptions "avatax" making it impossible to edit products in the catalog. it is safer coding to detect the missing index and not operate on the metadata.  after inserting the bypass if the avatax index does not exist in the given metadata everything started to function properly again.