### PR TITLE
Update to TaxClass.php

### DIFF
--- a/Helper/TaxClass.php
+++ b/Helper/TaxClass.php
@@ -129,7 +129,7 @@ class TaxClass
         if ($product->getTypeId() == self::PRODUCT_TYPE_GIFTCARD) {
             return self::GIFT_CARD_LINE_AVATAX_TAX_CODE;
         } else {
-            $simpleProduct = $this->productRepository->get($product->getSku());
+            $simpleProduct = $this->productRepository->getById($product->getId());
             return $this->getAvaTaxTaxCode($simpleProduct->getTaxClassId() ?: $product->getTaxClassId());
         }
     }


### PR DESCRIPTION
When using products that make use of the "Customizable Options" with values in "Sku" field. when calling the product->getSku() you get a sku with all selected options' sku tacked on with the product sku. then in productRepository->get($sku) the search for the sku fails and the user cannot add the product to the cart.