### PR TITLE
Remove bug disabling foreign keys

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -394,9 +394,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
         }
 
         if (version_compare($context->getVersion(), '2.0.4', '<')) {
-            $installer = $setup;
-            $installer->startSetup();
-
             $table_classyllama_avatax_crossbordertype = $setup->getConnection()
                 ->newTable($setup->getTable('classyllama_avatax_crossbordertype'));
 


### PR DESCRIPTION
By calling `startSetup` a second time, this is unknowingly disabling foreign keys. This can be proven by following the stack trace:

`$setup` or `$installer` is of type `\Magento\Framework\Setup\SchemaSetupInterface`.

```
-> % grep -rin 'implements SchemaSetupInterface' vendor/magento
vendor/magento/magento2-base/setup/src/Magento/Setup/Module/Setup.php:14:class Setup extends \Magento\Framework\Module\Setup implements SchemaSetupInterface
```

Which takes us to `Magento\Setup\Module\Setup`, but really we're after the class it extends (`\Magento\Framework\Module\Setup`) because this is where the `startSetup` method is implemented:

```
// \Magento\Framework\Module\Setup Line 173
/**
     * Prepare database before install/upgrade
     *
     * @return $this
     */
    public function startSetup()
    {
        $this->getConnection()->startSetup();
        return $this;
    }
```

The `getConnection` method here returns the type `\Magento\Framework\DB\Adapter\AdapterInterface`. After a quick grep, knowing that we are upgrading the schema of the DB we know this is coming from the MySql Adapter.

```
-> % grep -rin 'implements AdapterInterface' vendor/magento
vendor/magento/module-elasticsearch-7/SearchAdapter/Adapter.php:22:class Adapter implements AdapterInterface
vendor/magento/framework/Code/Minifier/Adapter/Js/JShrink.php:15:class JShrink implements AdapterInterface
vendor/magento/framework/Code/Minifier/Adapter/Css/CSSmin.php:14:class CSSmin implements AdapterInterface
vendor/magento/framework/Image/Adapter/AbstractAdapter.php:19:abstract class AbstractAdapter implements AdapterInterface
vendor/magento/framework/Translate/AbstractAdapter.php:12:abstract class AbstractAdapter extends \Zend_Translate_Adapter implements AdapterInterface
vendor/magento/framework/DB/Adapter/Pdo/Mysql.php:46:class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
vendor/magento/module-elasticsearch/Elasticsearch5/SearchAdapter/Adapter.php:20:class Adapter implements AdapterInterface
vendor/magento/magento2-base/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/AbstractAdapter.php:14:abstract class AbstractAdapter implements AdapterInterface
vendor/magento/magento2-base/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/ParserTest.php:184:class AdapterStub implements AdapterInterface
```

On line 2917 (version 2.4.1 of Magento) of the `\Magento\Framework\DB\Adapter\Pdo\Mysql` class we see the following:
```
    /**
     * Run additional environment before setup
     *
     * @return $this
     */
    public function startSetup()
    {
        $this->rawQuery("SET SQL_MODE=''");
        $this->rawQuery("SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0");
        $this->rawQuery("SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO'");

        return $this;
    }

    /**
     * Run additional environment after setup
     *
     * @return $this
     */
    public function endSetup()
    {
        $this->rawQuery("SET SQL_MODE=IFNULL(@OLD_SQL_MODE,'')");
        $this->rawQuery("SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS=0, 0, 1)");

        return $this;
    }
```

The issue here is that running this twice (which is happening on the proposed lines being removed) will end up setting `OLD_FOREIGN_KEY_CHECKS=0` on the second time, so when the `endSetup` method is run `FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS=0, 0, 1)` will set foreign keys = 0.

This has the ability to unknowingly create major data integrity issues and should be resolved immediately.