### PR TITLE
Fix cross_border_type DB schema upgrade

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -380,17 +380,22 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         // TODO: Consolidate with initial table creation above
         if (version_compare($context->getVersion(), '2.0.3', '<')) {
-            $setup->getConnection()->changeColumn(
-                $setup->getTable('avatax_cross_border_class'),
-                'cross_border_type',
-                'cross_border_type_id',
-                [
-                    'type'     => 'integer',
-                    'unsigned' => true,
-                    'nullable' => true,
-                    'length'   => 11,
-                ]
-            );
+            if ($setup->getConnection()->tableColumnExists(
+                'avatax_cross_border_class',
+                'cross_border_type'
+            )) {
+                $setup->getConnection()->changeColumn(
+                    $setup->getTable('avatax_cross_border_class'),
+                    'cross_border_type',
+                    'cross_border_type_id',
+                    [
+                        'type'     => 'integer',
+                        'unsigned' => true,
+                        'nullable' => true,
+                        'length'   => 11,
+                    ]
+                );
+            }
         }
 
         if (version_compare($context->getVersion(), '2.0.4', '<')) {


### PR DESCRIPTION
Running `magento setup:upgrade` while upgrading from v1.5.13 to v2.2.4 created the following error message:

```
Module 'ClassyLlama_AvaTax':
Upgrading schema..
Column "cross_border_type" does not exist in table "avatax_cross_border_class".
```

This pull request fixes this by checking if the column `cross_border_type` exists prior to attempting to rename it. In my instance the `cross_border_type_id` column was already in the DB, so renaming was unnecessary.