### PR TITLE
Do not touch other tables

### DIFF
--- a/Plugin/Model/ResourceModel/ExtensionAttributesPersistencePlugin.php
+++ b/Plugin/Model/ResourceModel/ExtensionAttributesPersistencePlugin.php
@@ -151,7 +151,9 @@ class ExtensionAttributesPersistencePlugin
             // The "if" have been added for excluding conflict with extension Magento_NegotiableQuote(Magento Commerce 2.3.*)
             // It will be removed after implementing the compatibility between ClassyLlama_AvaTax and Magento_B2b
             $tableNameExemptions = $this->config->getTableExemptions();
-            if(in_array($tableName, $tableNameExemptions)) { continue; }
+            if (in_array($tableName, $tableNameExemptions) || 0 !== strpos($tableName, 'avatax')) {
+                continue;
+            }
 
             $data = array_merge(...$tableData[$tableName]);
             $joinReferenceField = $tablesToUpdate[$tableName]['join_reference_field'];


### PR DESCRIPTION
The `ExtensionAttributesPersistencePlugin` plugin parses the `extension_attributes.xml` file and tries to add values to/delete from it. But not the only avatax extension adding such extension attributes that we should join. In my case, the avatax extension was removing data from the table from another module.

To prevent such an issue - I added a check for prefix. If the table name is NOT starting from avatax - we skip processing it so that other extensions won't be affected.