### PR TITLE
Add missing unique key to avatax_sales_order table

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -657,6 +657,20 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->createQueueBatchTransactionsTable($setup);
         }
 
+        if (version_compare($context->getVersion(), '2.2.4.1', '<')) {
+            $setup->getConnection(self::$connectionName)
+                ->addIndex(
+                    $setup->getTable('avatax_sales_order'),
+                    $setup->getIdxName(
+                        'avatax_sales_order',
+                        ['order_id'],
+                        \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
+                    ),
+                    ['order_id'],
+                    \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
+                );
+        }
+
         $setup->endSetup();
     }
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <!-- The setup_version attribute is unrelated to the module version stored in composer.json -->
-    <module name="ClassyLlama_AvaTax" setup_version="2.2.4">
+    <module name="ClassyLlama_AvaTax" setup_version="2.2.4.1">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Customer"/>


### PR DESCRIPTION
In case, when some external module does additional order save during placing an order, we have a duplicated values in the `avatax_sales_order` table. These duplicated values causing an exception on the checkout success page and customer sees the magento report page.

The investigation shown, that the duplicated value is added in the `ExtensionAttributesPersistencePlugin` plugin. It suppose to do insert and on duplicate - update the value, but since we don't have unique key for the order - the values just got duplicated.
https://github.com/avadev/Avalara-AvaTax-for-Magento2/blob/95072e49ea6a416b89e043ff5eacb40eabd9ddc0/Plugin/Model/ResourceModel/ExtensionAttributesPersistencePlugin.php#L185-L189

My PR adds missing unique key per order, and the issue is getting fixed.
Note: Magento automatically removes duplicated values from the table during index creation.