### PR TITLE
Add line level addresses support in the request

### DIFF
--- a/Framework/Interaction/Rest/Tax.php
+++ b/Framework/Interaction/Rest/Tax.php
@@ -229,7 +229,22 @@ class Tax extends Rest
             foreach ($request->getLines() as $line) {
                 $amount = ($line->hasAmount()) ? $line->getAmount() : 0;
                 $transactionBuilder->withLine($amount, $line->getQuantity(), $line->getItemCode(), $line->getTaxCode());
-
+                
+                if ($line->hasAddresses()) {
+                    foreach($line->getAddresses() as $addressType => $lineAddress) {
+                        $transactionBuilder->withLineAddress(
+                            $addressType,
+                            $lineAddress->getLine1(),
+                            $lineAddress->getLine2(),
+                            $lineAddress->getLine3(),
+                            $lineAddress->getCity(),
+                            $lineAddress->getRegion(),
+                            $lineAddress->getPostalCode(),
+                            $lineAddress->getCountry()
+                        );
+                    }
+                }
+                
                 if ($line->getTaxIncluded()) {
                     $transactionBuilder->withLineTaxIncluded();
                 }


### PR DESCRIPTION
The line object can be modified, e.g. in our case we can have different shipFrom addresses on the line level.
So if the customization of line object adds addresses then they also can be passed to the actual request object.