### PR TITLE
Use Document Created Date for Tax Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /Tests/Integration/credentials.php
+.DS_Store
+/vendor
+/.idea

--- a/Framework/Interaction/Rest/Tax.php
+++ b/Framework/Interaction/Rest/Tax.php
@@ -123,6 +123,7 @@ class Tax extends Rest
             'companyCode' => $request->getCompanyCode(),
             'type' => $request->getType(),
             'customerCode' => $request->getCustomerCode(),
+            'dateTime' => $request->getDate(),
         ]);
 
         $this->setTransactionDetails($transactionBuilder, $request);
@@ -315,6 +316,7 @@ class Tax extends Rest
                 'companyCode'  => $request->getCompanyCode(),
                 'type'         => $request->getType(),
                 'customerCode' => $request->getCustomerCode(),
+                'dateTime'     => $request->getDate(),
             ]);
             $this->setTransactionDetails($transactionBuilder, $request);
             try {

--- a/Framework/Interaction/Tax.php
+++ b/Framework/Interaction/Tax.php
@@ -663,6 +663,7 @@ class Tax
         $data = [
             'store_id' => $store->getId(),
             'commit' => $this->config->getCommitSubmittedTransactions($store),
+            'date' => $currentDate,
             'tax_override' => $taxOverride,
             'currency_code' => $order->getOrderCurrencyCode(),
             'customer_code' => $this->customer->getCustomerCodeByCustomerId(


### PR DESCRIPTION
The current implementation does not provide the document date. This causes the default date (now) to get sent in UTC, not the configured time zone for Magento.

The cron job will use the incorrect tax date when:
* Cron job runs on a different day than the sales document creation date (missed trigger or order submitted after 23:55:00)
* Sales document was created after the UTC offset for time zone set in Magento config. For example, if the offset is -05:00 then any order submitted after 19:00:00 Magento local time will have a tax date of the next day.