### PR TITLE
fix(config): use a real setting by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -19,7 +19,7 @@
         <tax>
             <avatax>
                 <enabled>0</enabled>
-                <tax_included>-1</tax_included>
+                <tax_included>0</tax_included>
                 <tax_mode>3</tax_mode>
                 <commit_submitted_transactions>1</commit_submitted_transactions>
                 <tax_calculation_countries_enabled>CA,US</tax_calculation_countries_enabled>


### PR DESCRIPTION
> If a change results in user programs breaking, it's a bug in the
kernel. We never EVER blame the user programs. How hard can this be to
understand?


This plugin breaks deployments of existing Avatax Magento 2 instances unless this setting is pre-set to 0 or 1. 

This has now caused two separate outages where tax was not charged to customers. 

This isn't a "read the fine print situtation". This is a "we broke your codebase" situation. 

This patch corrects the issue.