### PR TITLE
Fix duplicate type key error while doing setup:upgrade

### DIFF
--- a/BaseProvider/etc/di.xml
+++ b/BaseProvider/etc/di.xml
@@ -22,6 +22,7 @@
         <arguments>
             <argument name="collections" xsi:type="array">
                 <item name="baseprovider_queue_listing_data_source" xsi:type="string">BaseProviderQueueGridDataProvider</item>
+                <item name="baseprovider_log_listing_data_source" xsi:type="string">AvaTaxLogGridDataProvider</item>
             </argument>
         </arguments>
     </type>
@@ -39,7 +40,7 @@
     <type name="ClassyLlama\AvaTax\BaseProvider\Logger\GenericLogger">
         <arguments>
             <argument name="name" xsi:type="string">generic_logger</argument>
-            <argument name="handlers"  xsi:type="array">
+            <argument name="handlers" xsi:type="array">
                 <item name="1" xsi:type="object">ClassyLlama\AvaTax\BaseProvider\Logger\Handler\Generic\ApiHandler</item>
             </argument>
             <argument name="processors" xsi:type="array">
@@ -50,19 +51,12 @@
     <type name="ClassyLlama\AvaTax\BaseProvider\Logger\ApplicationLogger">
         <arguments>
             <argument name="name" xsi:type="string">logger</argument>
-            <argument name="handlers"  xsi:type="array">
+            <argument name="handlers" xsi:type="array">
                 <item name="1" xsi:type="object">ClassyLlama\AvaTax\BaseProvider\Logger\Handler\Application\FileHandler</item>
                 <item name="2" xsi:type="object">ClassyLlama\AvaTax\BaseProvider\Logger\Handler\Application\DbHandler</item>
             </argument>
             <argument name="processors" xsi:type="array">
                 <item name="1" xsi:type="object">ClassyLlama\AvaTax\BaseProvider\Logger\Processor</item>
-            </argument>
-        </arguments>
-    </type>
-	<type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
-        <arguments>
-            <argument name="collections" xsi:type="array">
-                <item name="baseprovider_log_listing_data_source" xsi:type="string">AvaTaxLogGridDataProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Currently setup:upgrade is not possible within Magento 2.4.5-p1:

```
$ bin/magento s:up                                                                          

More than one node matching the query: /config/type[@name='Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory'], Xml is: <?xml version="1.0"?>
<!--
/*
 * Avalara_BaseProvider
 *
 * NOTICE OF LICENSE
 *
 * This source file is subject to the Open Software License (OSL 3.0)
 * that is bundled with this package in the file LICENSE.txt.
 * It is also available through the world-wide-web at this URL:
 * http://opensource.org/licenses/osl-3.0.php
 *
 * @copyright Copyright (c) 2021 Avalara, Inc
 * @license    http: //opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 */
-->
...
```