### PR TITLE
Fix VAT Transport value when config value is null

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1349,7 +1349,7 @@ class Config extends AbstractHelper
             $store
         );
         if (is_null($VATTransportMapping)) {
-            $VATTransportMapping = '';
+            $VATTransportMapping = '[]';
         }
         return stripslashes((string)$VATTransportMapping);
     }


### PR DESCRIPTION
This fixes an exception that occurs when the VAT transport configuration was never given any values and returns null. It then assigns it to an empty string which later gets json unserialized and throws an exception. 

1. `ClassyLlama\AvaTax\Framework\Interaction` function `getTaxRequestForSalesObject($object)` line 708 retrieves the VAT transport config value.
2. Same function, line 710 attempts to unserialize an empty string which throws an exception because of a "Syntax error".