### PR TITLE
Add dependency to jQuery UI Widget module

### DIFF
--- a/view/adminhtml/web/js/view/address-validation-modal.js
+++ b/view/adminhtml/web/js/view/address-validation-modal.js
@@ -23,7 +23,8 @@ define([
     'ClassyLlama_AvaTax/js/lib/serialize-form',
     'ClassyLlama_AvaTax/js/lib/event.simulate',
     'Magento_Ui/js/modal/modal',
-    'prototype'
+    'prototype',
+    'jquery-ui-modules/widget'
 ], function(
     jQuery,
     alert,

--- a/view/frontend/web/js/addressValidation.js
+++ b/view/frontend/web/js/addressValidation.js
@@ -4,7 +4,7 @@
  */
 define([
     'jquery',
-    'jquery/ui',
+    'jquery-ui-modules/widget',
     'validation'
 ], function ($) {
     'use strict';

--- a/view/frontend/web/js/multishipping-address-validation.js
+++ b/view/frontend/web/js/multishipping-address-validation.js
@@ -4,8 +4,8 @@
  */
 define([
     'jquery',
-    'ClassyLlama_AvaTax/js/action/multishipping-save-address',
-    'jquery/ui',
+    'ClassyLlama_AvaTax/js/action/multishipping-save-address',,
+    'jquery-ui-modules/widget',
     'validation'
 ], function ($, multishippingSaveAddressAction) {
     'use strict';

--- a/view/frontend/web/js/view/address-validation-modal.js
+++ b/view/frontend/web/js/view/address-validation-modal.js
@@ -18,7 +18,8 @@ define([
     'ClassyLlama_AvaTax/js/action/set-customer-address',
     'ClassyLlama_AvaTax/js/model/address-converter',
     'ClassyLlama_AvaTax/js/view/address-validation-form',
-    'Magento_Ui/js/modal/modal'
+    'Magento_Ui/js/modal/modal',
+    'jquery-ui-modules/widget'
 ], function(
     $,
     ko,


### PR DESCRIPTION
On Magento 2.4.5 with enabled JS bundling (for example using https://github.com/magesuite/magepack) this extension adds JS error on checkout:
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/1873745/224014369-dffb168b-a84d-4eff-8ba2-85b4ae9d33cc.png">
This happens due to missing dependency to jquery-ui-modules/widget.
Also, this PR replaces `jquery/ui` to only `jquery-ui-modules/widget` to reduce the performance impact.