### PR TITLE
release/2.5.2

### DIFF
--- a/BaseProvider/Framework/Rest/ApiClient.php
+++ b/BaseProvider/Framework/Rest/ApiClient.php
@@ -28,6 +28,8 @@ use ClassyLlama\AvaTax\Helper\ApiLog;
  */
 class ApiClient
 {
+    public $auth;
+
     /**
      * @var ResponseFactory
      */
@@ -41,7 +43,7 @@ class ApiClient
     /**
      * @var bool The setting for whether the client should catch exceptions
      */
-    protected $catchExceptions;
+    protected $catchExceptions = true;
 
     /**
      * @var Array  Additional headers
@@ -79,7 +81,6 @@ class ApiClient
     ) {
         $this->clientFactory = $clientFactory;
         $this->responseFactory = $responseFactory;
-        $this->catchExceptions = true;
         $this->apiLog = $apiLog;
     }
 

--- a/BaseProvider/Logger/Handler/Application/FileHandler.php
+++ b/BaseProvider/Logger/Handler/Application/FileHandler.php
@@ -54,6 +54,11 @@ class FileHandler extends Base
     protected $loggerConfig;
 
     /**
+     * @var array
+     */
+    protected $processors = [];
+
+    /**
      * @param Config $config
      * @param DriverInterface $filesystem
      */

--- a/BaseProvider/Logger/Handler/BaseAbstractHandler.php
+++ b/BaseProvider/Logger/Handler/BaseAbstractHandler.php
@@ -26,6 +26,11 @@ use ClassyLlama\AvaTax\BaseProvider\Exception\AvalaraLoggerException;
  */
 class BaseAbstractHandler extends AbstractHandler
 {
+    /**
+     * @var array
+     */
+    protected $processors = [];
+
     public function __construct($level = Logger::DEBUG, $bubble = true)
     {
         parent::__construct($level, $bubble);

--- a/BaseProvider/Model/QueueRepository.php
+++ b/BaseProvider/Model/QueueRepository.php
@@ -27,6 +27,8 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 class QueueRepository implements QueueRepositoryInterface
 {
+    public $collectionFactory;
+    
     /**
      * @var QueueFactory
      */
@@ -56,7 +58,7 @@ class QueueRepository implements QueueRepositoryInterface
         $this->QueueFactory = $QueueFactory;
         $this->QueueCollectionFactory = $QueueCollectionFactory;
         $this->searchResultFactory = $QueueSearchResultsInterfaceFactory;
-        $this->collectionProcessor = collectionProcessor;
+        $this->collectionProcessor = $collectionProcessor;
     }
  
     public function getList(SearchCriteriaInterface $searchCriteria)

--- a/Controller/Certificates/Unlink.php
+++ b/Controller/Certificates/Unlink.php
@@ -26,7 +26,7 @@ class Unlink extends \Magento\Framework\App\Action\Action
     /**
      * @var \ClassyLlama\AvaTax\Helper\CertificateUnlinkHelper
      */
-    protected $CertificateUnlinkHelper;
+    protected $certificateUnlinkHelper;
 
     /**
      * Delete constructor.

--- a/Framework/AppInterface.php
+++ b/Framework/AppInterface.php
@@ -24,7 +24,7 @@ interface AppInterface
 	/**
      * Avalara APP String
      */
-    const CONNECTOR_STRING = 'a0o5a000007hWJMAA2';
+    const CONNECTOR_STRING = 'a0o5a000007m3XbAAI';
 	/**
      * Avalara Connector name
      */

--- a/Framework/Interaction/Rest/ClientPool.php
+++ b/Framework/Interaction/Rest/ClientPool.php
@@ -90,7 +90,10 @@ class ClientPool
         }
 
         $cacheKey = $this->getClientCacheKey($isProduction, $scopeType, $scopeId);
-
+        $guzzleParams = [];
+        $guzzleParams['timeout'] = $this->config->getAvaTaxApiTimeout(); // Response timeout
+        $guzzleParams['connect_timeout'] = $this->config->getAvaTaxApiTimeout(); // Connection timeout
+        
         if (!isset($this->clients[$cacheKey])) {
             /** @var AvaTaxClientWrapper $avaTaxClient */
             $avaTaxClient = $this->avaTaxClientFactory->create(
@@ -99,6 +102,7 @@ class ClientPool
                     'appVersion' => $this->config->getConnectorString(),
                     'machineName' => $this->config->getApplicationDomain(),
                     'environment' => $isProduction ? self::API_MODE_PROD : self::API_MODE_DEV,
+                    'guzzleParams' => $guzzleParams
                 ]
             );
 			

--- a/Framework/Interaction/Rest/Definitions.php
+++ b/Framework/Interaction/Rest/Definitions.php
@@ -35,6 +35,11 @@ class Definitions extends \ClassyLlama\AvaTax\Framework\Interaction\Rest
     protected $definitionsResultFactory;
 
     /**
+     * @var ApiLog
+     */
+    protected $apiLog;
+
+    /**
      * @param LoggerInterface $logger
      * @param DataObjectFactory $dataObjectFactory
      * @param ClientPool $clientPool

--- a/Framework/Interaction/Tax.php
+++ b/Framework/Interaction/Tax.php
@@ -249,6 +249,11 @@ class Tax
     protected $scopeConfig;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    protected $serialize;
+
+    /**
      * @param Address                                       $address
      * @param Config                                        $config
      * @param \ClassyLlama\AvaTax\Helper\TaxClass           $taxClassHelper

--- a/Helper/AvaTaxClientWrapper.php
+++ b/Helper/AvaTaxClientWrapper.php
@@ -118,10 +118,16 @@ class AvaTaxClientWrapper extends \Avalara\AvaTaxClient
         if (!isset($guzzleParams['timeout'])) {
             $guzzleParams['timeout'] = $this->config->getAvaTaxApiTimeout();
         }
+        if (!isset($guzzleParams['connect_timeout'])) {
+            $guzzleParams['connect_timeout'] = $this->config->getAvaTaxApiTimeout();
+        }        
 
         // Warning: This causes the value to revert to the default "forever" timeout in guzzle
         if (\is_nan($guzzleParams['timeout'])) {
             $guzzleParams['timeout'] = 0;
+        }
+        if (\is_nan($guzzleParams['connect_timeout'])) {
+            $guzzleParams['connect_timeout'] = 0;
         }
 
         return parent::restCall($apiUrl, $verb, $guzzleParams);

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -260,6 +260,8 @@ class Config extends AbstractHelper
      */
     const AVATAX_CACHE_TAG = 'AVATAX';
     
+    public $avaTaxConfigFactory;
+    
     /**
      * @var ProductMetadataInterface
      */

--- a/Model/Factory/LinkCertificatesModelFactory.php
+++ b/Model/Factory/LinkCertificatesModelFactory.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * ClassyLlama_AvaTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright  Copyright (c) 2018 Avalara, Inc.
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace ClassyLlama\AvaTax\Model\Factory;
+
+/**
+ * Factory class for @see \Avalara\LinkCertificatesModel
+ */
+class LinkCertificatesModelFactory
+{
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    protected $_objectManager = null;
+
+    /**
+     * Instance name to create
+     *
+     * @var string
+     */
+    protected $_instanceName = null;
+
+    /**
+     * Factory constructor
+     *
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param string $instanceName
+     */
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $instanceName = '\\Avalara\\LinkCertificatesModel'
+    )
+    {
+        $this->_objectManager = $objectManager;
+        $this->_instanceName = $instanceName;
+    }
+
+    /**
+     * Create class instance with specified parameters
+     *
+     * @param array $data
+     * @return \Avalara\LinkCertificatesModel
+     */
+    public function create(array $data = array())
+    {
+        return $this->_objectManager->create($this->_instanceName, $data);
+    }
+}

--- a/etc/adminhtml/system/error_logs_and_queue.xml
+++ b/etc/adminhtml/system/error_logs_and_queue.xml
@@ -51,6 +51,7 @@
                 </depends>
             </field>
             <field id="avatax_timeout" translate="label comment" type="text" sortOrder="2050" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <config_path>tax/avatax_advanced/avatax_timeout</config_path>
                 <label>AvaTax API Timeout</label>
                 <comment><![CDATA[This field defines how long Magento should wait to hear from AvaTax's servers before assuming no response will be given.]]></comment>
             </field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -75,7 +75,7 @@
             </avatax_document_management>
             <avatax_advanced>
                 <response_logging_enabled>1</response_logging_enabled>
-                <avatax_timeout>15</avatax_timeout>
+                <avatax_timeout>60</avatax_timeout>
                 <avatax_adjustment_taxes>0</avatax_adjustment_taxes>
                 <avatax_table_exemptions>negotiable_quote_item,company_order_entity</avatax_table_exemptions>
                 <result_cache_ttl>15</result_cache_ttl>


### PR DESCRIPTION
Tax refund issue
Users encountered the ErrorCountLimitExceededError error when creating tax refund requests to AvaTax. This issue has now been fixed.

Transactions in AvaTax sandbox account
The issue with the sandbox account where transactions were reflecting in Magento but not in AvaTax and throwing an error is fixed.

Address Validation
The issue with address validation where the corrected address was not getting updated has been fixed.

Timeout error with AvaTax CURL
Users were getting a CURL timeout error when saving customer data from the Magento admin console when the customer account is having a tax exemption certificate. This issue has been fixed.

The Connector for Magento 2 for Sales Tax supports Magento 2 Community, Enterprise, and Magento Cloud platform versions 2.4.5 and 2.4.6