### PR TITLE
release/2.5.3

### DIFF
--- a/BaseProvider/Logger/Handler/Generic/ApiHandler.php
+++ b/BaseProvider/Logger/Handler/Generic/ApiHandler.php
@@ -111,6 +111,7 @@ class ApiHandler extends BaseAbstractHandler
             $headers = isset($apiConfig['config']['extra_headers']) ? $apiConfig['config']['extra_headers'] : [];
             $extraParams = isset($apiConfig['config']['extra_params']) ? $apiConfig['config']['extra_params'] : [];
             $requestMethod = isset($apiConfig['config']['request_method']) ? $apiConfig['config']['request_method'] : Request::HTTP_METHOD_POST;
+            $ERPDetails = isset($apiConfig['config']['ERPDetails']) ? $apiConfig['config']['ERPDetails'] : Config::ERP_DETAILS;
 
             if ($currentMode == Config::API_MODE_SANDBOX) {
                 $endPointBaseUrl = Config::ENV_LOGGER_SANDBOX_BASE_URL;
@@ -130,7 +131,7 @@ class ApiHandler extends BaseAbstractHandler
 
             $params["CallerAccuNum"] = $accountNumber;
             $params["AvaTaxEnvironment"] = ucwords($currentMode);
-            $params["ERPDetails"] = Config::ERP_DETAILS;
+            $params["ERPDetails"] = $ERPDetails;
             $params["ConnectorName"] = $connectorName;
             $params["ConnectorVersion"] = $connectorVersion;
             $params["ClientString"] = $connectorString;

--- a/Block/Adminhtml/Customer/Edit/Region.php
+++ b/Block/Adminhtml/Customer/Edit/Region.php
@@ -50,6 +50,6 @@ class Region extends \Magento\Framework\View\Element\Template
      */
     public function isAddressValidationEnabled()
     {
-        return $this->configHelper->isAddressValidationEnabled($this->_storeManager->getStore());
+        return $this->configHelper->isModuleEnabled($this->_storeManager->getStore()) && $this->configHelper->isAddressValidationEnabled($this->_storeManager->getStore());
     }
 }

--- a/Framework/AppInterface.php
+++ b/Framework/AppInterface.php
@@ -20,7 +20,7 @@ interface AppInterface
     /**
      * Connector version
      */
-    const APP_VERSION = '2.5.2';
+    const APP_VERSION = '2.5.3';
 	/**
      * Avalara APP String
      */

--- a/Framework/Interaction/Request/CreditmemoRequestBuilder.php
+++ b/Framework/Interaction/Request/CreditmemoRequestBuilder.php
@@ -595,7 +595,7 @@ class CreditmemoRequestBuilder implements CreditmemoRequestBuilderInterface
         $request->setData('store_id', $store->getId());
         $request->setData('commit', self::COMMIT_TRANSACTION);
         $request->setData('tax_override', $taxOverride);
-        $request->setData('currency_code', $order->getOrderCurrencyCode());
+        $request->setData('currency_code', $order->getGlobalCurrencyCode());
         $request->setData('customer_code', $this->customer->getCustomerCodeByCustomerId(
             $order->getCustomerId(),
             $order->getId(),

--- a/Framework/Interaction/Tax.php
+++ b/Framework/Interaction/Tax.php
@@ -472,12 +472,12 @@ class Tax
 			}
 		}
         $currencyCode = $quote->getCurrency()->getQuoteCurrencyCode();
-        $shippingAmount = number_format($shippingAddress->getAddress()->getShippingAmount(), '2', '.', ',');
+        $shippingAmount = number_format((float)$shippingAddress->getAddress()->getShippingAmount(), '2', '.', ',');
         $shippingParametersValue = $shipToAddress->getCountry().":".$shipToAddress->getRegion().":".$shippingAddress->getMethod().":".$shippingAmount." ".$currencyCode;
         $data = [
             'store_id' => $store->getId(),
             'commit' => false, // quotes should never be committed
-            'currency_code' => $quote->getCurrency()->getQuoteCurrencyCode(),
+            'currency_code' => $quote->getCurrency()->getBaseCurrencyCode(),
             'customer_code' => $this->customer->getCustomerCodeByCustomerId(
                 $quote->getCustomerId(),
                 $quote->getId(),
@@ -767,14 +767,14 @@ class Tax
             }
         }
         $currencyCode = $order->getOrderCurrencyCode();
-        $shippingAmount = number_format($order->getShippingAmount(), '2', '.', ',');
+        $shippingAmount = number_format((float)$order->getShippingAmount(), '2', '.', ',');
         $shippingParametersValue = $shipToAddress->getCountry().":".$shipToAddress->getRegion().":".$order->getShippingMethod().":".$shippingAmount." ".$currencyCode;
         $data = [
             'store_id' => $store->getId(),
             'commit' => $this->config->getCommitSubmittedTransactions($store),
             'date' => $currentDate,
             'tax_override' => $taxOverride,
-            'currency_code' => $order->getOrderCurrencyCode(),
+            'currency_code' => $order->getGlobalCurrencyCode(),
             'customer_code' => $this->customer->getCustomerCodeByCustomerId(
                 $order->getCustomerId(),
                 $order->getId(),

--- a/Helper/ApiLog.php
+++ b/Helper/ApiLog.php
@@ -68,6 +68,7 @@ class ApiLog extends AbstractHelper
             $isProduction = $this->config->isProductionMode($scopeId, $scopeType);
             $accountNumber = $this->config->getAccountNumber($scopeId, $scopeType, $isProduction);
             $accountSecret = $this->config->getLicenseKey($scopeId, $scopeType, $isProduction);
+            $ERPDetails = $this->config->getERPDetails();
             $connectorId = self::CONNECTOR_ID;
             $clientString = self::APP_NAME;
             $connectorVersion = self::APP_VERSION;
@@ -94,6 +95,7 @@ class ApiLog extends AbstractHelper
                     'log_type' => $logType,
                     'log_level' => $logLevel,
                     'function_name' => $functionName,
+                    'ERPDetails' => $ERPDetails,
                     'extra_params' => isset($context['config']['extra_params']) ? $context['config']['extra_params'] : []
                 ]
             ];

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1013,6 +1013,17 @@ class Config extends AbstractHelper
      */
     public function isAddressValidationEnabled($store)
     {
+        return $this->isModuleEnabled($store) && $this->getAddressValidationConfig($store);
+    }
+    /**
+     * Return address validation config value
+     *
+     * @param null $store
+     *
+     * @return mixed
+     */
+    public function getAddressValidationConfig($store)
+    {
         return $this->scopeConfig->getValue(
             self::XML_PATH_AVATAX_ADDRESS_VALIDATION_ENABLED,
             ScopeInterface::SCOPE_STORE,
@@ -1360,5 +1371,22 @@ class Config extends AbstractHelper
             $VATTransportMapping = '';
         }
         return stripslashes((string)$VATTransportMapping);
+    }
+
+    /**
+     * Get ERP Details with magento edition and version
+     * 
+     * @return string
+     */
+    public function getERPDetails() {
+        $edition = 'CE';
+
+        if ($this->magentoProductMetadata->getEdition() == "Enterprise") {
+            $edition = 'EE';
+        }
+
+        $version = $this->magentoProductMetadata->getVersion();
+
+        return "MAGENTO " . $edition . " " . $version;
     }
 }

--- a/Helper/Multishipping/Checkout/AddressValidation.php
+++ b/Helper/Multishipping/Checkout/AddressValidation.php
@@ -75,7 +75,7 @@ class AddressValidation
      */
     public function isValidationEnabled()
     {
-        return $this->config->isAddressValidationEnabled($this->storeManager->getStore());
+        return $this->config->isModuleEnabled($this->storeManager->getStore()) && $this->config->isAddressValidationEnabled($this->storeManager->getStore());
     }
 
     /**

--- a/etc/adminhtml/system/extension_mode.xml
+++ b/etc/adminhtml/system/extension_mode.xml
@@ -27,6 +27,7 @@
             <label>Enable AvaTax</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <backend_model>ClassyLlama\AvaTax\Model\Config\Backend\ConnectorStatus</backend_model>
+            <comment><![CDATA[If disabled, the connector settings are unavailable for all users. AvaTax tax calculation and address validation services are also unavailable even if you've enabled them in the settings.]]></comment>
         </field>
         <field id="live_mode" translate="label" type="select" sortOrder="1020" showInDefault="1" showInWebsite="1" showInStore="1">
             <config_path>tax/avatax/live_mode</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -23,7 +23,7 @@
                 <tax_mode>3</tax_mode>
                 <commit_submitted_transactions>1</commit_submitted_transactions>
                 <tax_calculation_countries_enabled>CA,US</tax_calculation_countries_enabled>
-                <use_business_identification_number>1</use_business_identification_number>
+                <use_business_identification_number>0</use_business_identification_number>
                 <shipping_tax_code>FR020100</shipping_tax_code>
                 <sku_shipping>Shipping</sku_shipping>
                 <sku_gift_wrap_order>GwOrder</sku_gift_wrap_order>
@@ -34,7 +34,7 @@
                 <error_action>2</error_action>
                 <error_action_disable_checkout_message_frontend>Unfortunately, we could not calculate tax for your order. Please try again with a different address or contact us to complete your order.</error_action_disable_checkout_message_frontend>
                 <error_action_disable_checkout_message_backend><![CDATA[There was an error getting tax rates from Avalara and since the "Error Action" is configured to "Disable checkout & show error message", we have blocked the checkout. Change <a href="%1">this setting here</a>. Please see the <a href="%2">error log</a> for details.]]></error_action_disable_checkout_message_backend>
-                <address_validation_enabled>1</address_validation_enabled>
+                <address_validation_enabled>0</address_validation_enabled>
                 <address_validation_user_has_choice>1</address_validation_user_has_choice>
                 <address_validation_instructions_with_choice><![CDATA[To ensure accurate delivery, we suggest the changes highlighted below. Please choose which address you would like to use. If neither option is correct, <a href="#" class="edit-address">edit your address</a>.]]></address_validation_instructions_with_choice>
                 <address_validation_instructions_without_choice><![CDATA[To ensure accurate delivery, we've made the changes highlighted below. If this address is not correct, <a href="#" class="edit-address">edit your address</a>.]]></address_validation_instructions_without_choice>

--- a/view/base/web/css/source/_address-validation.less
+++ b/view/base/web/css/source/_address-validation.less
@@ -55,6 +55,15 @@
         }
     }
 
+    .legend {
+        margin: 0;
+        padding: 0;
+        border-bottom: none;
+        .step-title {
+            padding-bottom: 15px;
+        }
+    }
+
     .validatedAddress {
         margin-top: 10px;
         padding: 10px;

--- a/view/base/web/template/modal/modal-popup.html
+++ b/view/base/web/template/modal/modal-popup.html
@@ -1,0 +1,62 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+<aside role="dialog"
+       class="modal-<%- data.type %> <%- data.modalClass %>
+               <% if(data.responsive){ %><%- data.responsiveClass %><% } %>
+               <% if(data.innerScroll){ %><%- data.innerScrollClass %><% } %>"
+       <% if(data.title){ %> aria-labelledby="modal-title-<%- data.id %>"<% } %>
+       aria-describedby="modal-content-<%- data.id %>"
+       data-role="modal"
+       data-type="<%- data.type %>"
+       tabindex="0">
+    <div data-role="focusable-start" tabindex="0"></div>
+    <div class="modal-inner-wrap"
+         data-role="focusable-scope">
+        <fieldset class="fieldset">
+            <header class="modal-header">
+                <% if(data.title || data.subTitle){ %>
+                <legend>
+                    <h1 id="modal-title-<%- data.id %>" class="modal-title"
+                        data-role="title">
+                        <% if(data.title){ %>
+                            <%= data.title %>
+                        <% } %>
+        
+                        <% if(data.subTitle){ %>
+                        <span class="modal-subtitle"
+                            data-role="subTitle">
+                            <%= data.subTitle %>
+                        </span>
+                        <% } %>
+                    </h1>
+                </legend>
+                <% } %>
+                <button
+                    class="action-close"
+                    data-role="closeBtn"
+                    type="button">
+                    <span><%= data.closeText %></span>
+                </button>
+            </header>
+            <div id="modal-content-<%- data.id %>"
+                class="modal-content"
+                data-role="content"></div>
+        </fieldset>
+        <% if(data.buttons.length > 0){ %>
+        <footer class="modal-footer">
+            <% _.each(data.buttons, function(button) { %>
+            <button
+                class="<%- button.class %>"
+                type="button"
+                data-role="action"><span><%= button.text %></span></button>
+            <% }); %>
+        </footer>
+        <% } %>
+    </div>
+    <div data-role="focusable-end" tabindex="0"></div>
+</aside>

--- a/view/frontend/templates/init_checkout_billing_validation_modal.phtml
+++ b/view/frontend/templates/init_checkout_billing_validation_modal.phtml
@@ -23,11 +23,3 @@
 <script type="text/javascript">
     window.avaTaxStoreCode = "<?= $this->getStoreCode() ?>";
 </script>
-
-<script type="text/x-magento-init">
-    {
-        "*": {
-            "checkoutBillingAddressValidationModal": {}
-        }
-    }
-</script>

--- a/view/frontend/web/js/view/address-validation-modal.js
+++ b/view/frontend/web/js/view/address-validation-modal.js
@@ -18,6 +18,7 @@ define([
     'ClassyLlama_AvaTax/js/action/set-customer-address',
     'ClassyLlama_AvaTax/js/model/address-converter',
     'ClassyLlama_AvaTax/js/view/address-validation-form',
+    'text!ClassyLlama_AvaTax/template/modal/modal-popup.html',
     'Magento_Ui/js/modal/modal'
 ], function(
     $,
@@ -25,7 +26,8 @@ define([
     addressModel,
     setCustomerAddress,
     addressConverter,
-    addressValidationForm
+    addressValidationForm,
+    popupTpl
 ){
 
     $.widget('ClassyLlama_AvaTax.addressValidationModal', $.mage.modal, {
@@ -35,6 +37,7 @@ define([
             focus: '.validationModal .action-primary',
             responsive: true,
             closeText: $.mage.__('Close'),
+            popupTpl: popupTpl,
             buttons: [
                 {
                     text: $.mage.__('Edit Address'),

--- a/view/frontend/web/js/view/checkout-billing-address-validation-modal.js
+++ b/view/frontend/web/js/view/checkout-billing-address-validation-modal.js
@@ -18,7 +18,8 @@ define([
     'ClassyLlama_AvaTax/js/view/address-validation-form',
     'Magento_Checkout/js/model/checkout-data-resolver',
     'Magento_Checkout/js/action/select-billing-address',
-    'Magento_Checkout/js/action/create-billing-address'
+    'Magento_Checkout/js/action/create-billing-address',
+    'text!ClassyLlama_AvaTax/template/modal/modal-popup.html'
 ], function (
     $,
     ko,
@@ -26,7 +27,8 @@ define([
     addressValidationForm,
     checkoutDataResolver,
     selectBillingAddress,
-    createBillingAddress
+    createBillingAddress,
+    popupTpl
 ) {
 
     $.widget('ClassyLlama_AvaTax.checkoutBillingAddressValidationModal', $.mage.modal, {
@@ -38,6 +40,7 @@ define([
             focus: '.billingValidationModal .action-primary',
             responsive: true,
             closeText: $.mage.__('Close'),
+            popupTpl: popupTpl,
             buttons: [
                 {
                     text: $.mage.__('Edit Address'),

--- a/view/frontend/web/template/checkoutValidateAddress.html
+++ b/view/frontend/web/template/checkoutValidateAddress.html
@@ -14,8 +14,12 @@
  */
 -->
 <li id="validate_address" role="presentation" class="checkout-validate-address" data-bind="fadeVisible: isVisible">
-    <div class="step-title" data-bind="i18n: 'Verify Your Address'" data-role="title"></div>
-    <div class="step-content" data-role="content" role="tabpanel" aria-hidden="false">
-        <!-- ko template: getBaseValidateAddressTemplate() --><!-- /ko -->
-    </div>
+    <fieldset class="fieldset">
+        <legend class="legend">
+            <div class="step-title" data-bind="i18n: 'Verify Your Address'" data-role="title"></div>
+        </legend>
+        <div class="step-content" data-role="content" role="tabpanel" aria-hidden="false">
+            <!-- ko template: getBaseValidateAddressTemplate() --><!-- /ko -->
+        </div>
+    </fieldset>
 </li>


### PR DESCRIPTION
**Fixes**
 
Australia cross-border transactions
The cross-border transactions for Australia faced an issue with order amounts calculated in USD instead of AUD. The cart displayed the order amount in AUD but the amount is in USD. This release fixes this issue.
 
**Virtual orders**
Users faced an error and the tax wasn’t getting calculated when processing a virtual order. This release fixes this issue.
