### PR TITLE
replace Zend Serializer with Laminas Serializer dependency

### DIFF
--- a/Framework/Interaction/Rest/Tax/Cacheable.php
+++ b/Framework/Interaction/Rest/Tax/Cacheable.php
@@ -25,7 +25,7 @@ use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Exception\LocalizedException;
 use ClassyLlama\AvaTax\Framework\Interaction\Rest\Tax\Result as TaxResult;
 use ClassyLlama\AvaTax\Exception\AvataxConnectionException;
-use Zend\Serializer\Adapter\PhpSerialize;
+use Laminas\Serializer\Adapter\PhpSerialize;
 
 /**
  * Class Cacheable


### PR DESCRIPTION
This fix replaces the Zend Serializer class with the Laminas Serializer class which is the actual dependency specified in the composer.json file.

It also resolves an error that was showing because the Zend class does not exist.