### PR TITLE
Update inline javascript tags to comply with CSP after the 2.4.7 magento release.

### DIFF
--- a/view/frontend/templates/checkout/billing.phtml
+++ b/view/frontend/templates/checkout/billing.phtml
@@ -16,15 +16,18 @@ use ClassyLlama\AvaTax\Block\Multishipping\Checkout\Billing;
              style="position: absolute;">
     </div>
 </div>
-<script>
-    window.checkoutConfig = <?= /* @noEscape */ $block->getCheckoutData()->getSerializedCheckoutConfigs(); ?>;
+
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "
+    window.checkoutConfig = " . $block->getCheckoutData()->getSerializedCheckoutConfigs() . ";
     window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
     window.customerData = window.checkoutConfig.customerData;
-</script>
+", false); ?>
+
 <div data-mage-init='{"multiShippingAddressValidation":{}}'></div>
+
 <div id="checkout" data-bind="scope:'checkoutMessages'">
     <!-- ko template: getTemplate() --><!-- /ko -->
-    <script type="text/x-magento-init">
+    <?= $secureRenderer->renderTag('script', ['type' => 'text/x-magento-init'], '
         {
             "#checkout": {
                 "Magento_Ui/js/core/app": {
@@ -37,8 +40,9 @@ use ClassyLlama\AvaTax\Block\Multishipping\Checkout\Billing;
                 }
             }
         }
-    </script>
+    ', false); ?>
 </div>
+
 <form action="<?= $block->escapeUrl($block->getPostActionUrl()); ?>"
       method="post"
       id="multishipping-billing-form"
@@ -211,28 +215,28 @@ use ClassyLlama\AvaTax\Block\Multishipping\Checkout\Billing;
         </div>
     </div>
 </form>
-<script>
-    require(['jquery', 'mage/mage'], function (jQuery) {
+
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "
+require(['jquery', 'mage/mage'], function (jQuery) {
         var addtocartForm = jQuery('#multishipping-billing-form');
 
         addtocartForm.mage('payment', {
-            checkoutPrice: <?= (float)$block->getQuoteBaseGrandTotal() ?>
+            checkoutPrice: " . (float)$block->getQuoteBaseGrandTotal() . "
         });
 
         addtocartForm.mage('validation', {
             errorPlacement: function (error, element) {
                 if (element.attr('data-validate') && element.attr('data-validate').indexOf('validate-cc-ukss') >= 0) {
-                    element.parents('form').find('[data-validation-msg="validate-cc-ukss"]').html(error);
+                    element.parents('form').find('[data-validation-msg=\"validate-cc-ukss\"]').html(error);
                 } else {
                     element.after(error);
                 }
             }
         });
     });
-</script>
+", false); ?>
 
-<script>
-    //<![CDATA[
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "
     require(
         [
             'Magento_Checkout/js/model/quote',
@@ -240,24 +244,24 @@ use ClassyLlama\AvaTax\Block\Multishipping\Checkout\Billing;
             'domReady!'
         ], function (quote, $) {
             quote.billingAddress({
-                city: '<?= /* @noEscape */ $block->getAddress()->getCity() ?>',
-                company: '<?= /* @noEscape */ $block->getAddress()->getCompany(); ?>',
-                countryId: '<?= /* @noEscape */ $block->getAddress()->getCountryId(); ?>',
-                customerAddressId: '<?= /* @noEscape */ $block->getAddress()->getCustomerAddressId(); ?>',
-                customerId: '<?= /* @noEscape */ $block->getAddress()->getCustomerId(); ?>',
-                fax: '<?= /* @noEscape */ $block->getAddress()->getFax(); ?>',
-                firstname: '<?= /* @noEscape */ $block->getAddress()->getFirstname(); ?>',
-                lastname: '<?= /* @noEscape */ $block->getAddress()->getLastname(); ?>',
-                postcode: '<?= /* @noEscape */ $block->getAddress()->getPostcode(); ?>',
-                regionId: '<?= /* @noEscape */ $block->getAddress()->getRegionId(); ?>',
-                regionCode: '<?= /* @noEscape */ $block->getAddress()->getRegionCode() ?>',
-                region: '<?= /* @noEscape */ $block->getAddress()->getRegion(); ?>',
-                street: <?= /* @noEscape */ json_encode($block->getAddress()->getStreet()); ?>,
-                telephone: '<?= /* @noEscape */ $block->getAddress()->getTelephone(); ?>'
+                city: '" . $block->getAddress()->getCity() . "',
+                company: '" . $block->getAddress()->getCompany() . "',
+                countryId: '" . $block->getAddress()->getCountryId() . "',
+                customerAddressId: '" . $block->getAddress()->getCustomerAddressId() . "',
+                customerId: '" . $block->getAddress()->getCustomerId() . "',
+                fax: '" . $block->getAddress()->getFax() . "',
+                firstname: '" . $block->getAddress()->getFirstname() . "',
+                lastname: '" . $block->getAddress()->getLastname() . "',
+                postcode: '" . $block->getAddress()->getPostcode() . "',
+                regionId: '" . $block->getAddress()->getRegionId() . "',
+                regionCode: '" . $block->getAddress()->getRegionCode() . "',
+                region: '" . $block->getAddress()->getRegion() . "',
+                street: " . json_encode($block->getAddress()->getStreet()) . ",
+                telephone: '" . $block->getAddress()->getTelephone() . "'
             });
         });
-    //]]>
-</script>
-<script type="text/javascript">
-    window.avaTaxStoreCode = "<?= $this->getStoreCode() ?>";
-</script>
+", false); ?>
+
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "
+    window.avaTaxStoreCode = " . $this->getStoreCode() . ";
+", false); ?>

--- a/view/frontend/templates/checkout/shipping.phtml
+++ b/view/frontend/templates/checkout/shipping.phtml
@@ -229,6 +229,5 @@ use ClassyLlama\AvaTax\Block\Multishipping\Checkout\Shipping;
     </div>
 </form>
 
-<script type="text/javascript">
-    window.avaTaxStoreCode = "<?= $block->getStoreCode() ?>";
-</script>
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "\nwindow.avaTaxStoreCode = " . $this->getStoreCode() .";\n", false); ?>
+

--- a/view/frontend/templates/init_checkout_billing_validation_modal.phtml
+++ b/view/frontend/templates/init_checkout_billing_validation_modal.phtml
@@ -13,13 +13,12 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 ?>
-<script>
-    require([
-        'mage/url'
-    ], function (url) {
-        return url.setBaseUrl('<?php /* @escapeNotVerified */ echo $block->getUrl();?>');
-    })
-</script>
-<script type="text/javascript">
-    window.avaTaxStoreCode = "<?= $this->getStoreCode() ?>";
-</script>
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "
+        require([
+            'mage/url'
+        ], function (url) {
+            return url.setBaseUrl('" . $block->getUrl() . "');
+        });
+", false); ?>
+
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "\nwindow.avaTaxStoreCode = " . $this->getStoreCode() .";\n", false); ?>

--- a/view/frontend/templates/init_validation_modal.phtml
+++ b/view/frontend/templates/init_validation_modal.phtml
@@ -13,31 +13,29 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 ?>
-<script type="text/x-magento-init">
+<?= $secureRenderer->renderTag('script', ['type' => 'text/x-magento-init'], '
     {
         "*": {
             "addressValidationModal": {
-                "validationEnabled": <?= (int)$this->isValidationEnabled() ?>,
-                "hasChoice": <?= $this->getChoice() ?>,
-                "instructions": <?= $this->getInstructions() ?>,
-                "errorInstructions": <?= $this->getErrorInstructions() ?>,
-                "countriesEnabled": "<?= $this->getCountriesEnabled() ?>"
+                "validationEnabled": ' . (int)$this->isValidationEnabled() . ',
+                "hasChoice": "' . $this->getChoice() . '",
+                "instructions": "' . $this->getInstructions() . '",
+                "errorInstructions": "' . $this->getErrorInstructions() . '",
+                "countriesEnabled": "' . $this->getCountriesEnabled() . '"
             }
         }
     }
-</script>
-<script>
+', false); ?>
+
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "
     require([
         'mage/url'
     ], function(url) {
-        <?php
         // Set baseUrl so that the urlBuilder JS module has access to it
         // Calling getUrl instead of getBaseUrl as the latter has been overridden in
         // \ClassyLlama\AvaTax\Block\CustomerAddress to return a different url
-        ?>
-        return url.setBaseUrl('<?php /* @escapeNotVerified */ echo $block->getUrl();?>');
-    })
-</script>
-<script type="text/javascript">
-    window.avaTaxStoreCode = "<?= $this->getStoreCode() ?>";
-</script>
+        return url.setBaseUrl('" . $block->getUrl() . "');
+    });
+", false); ?>
+
+<?= $secureRenderer->renderTag('script', ['type' => 'text/javascript'], "\nwindow.avaTaxStoreCode = " . $this->getStoreCode() . ";\n", false); ?>


### PR DESCRIPTION
This pull request uses `$secureRenderer->renderTag` in place of inline JavaScript `<script>` tags to comply with `restrict-mode` being the default on payment pages. Please note that `unsafe-inline` has also been removed from payment pages in Magento 2.4.7.

You can read more about it here:
https://developer.adobe.com/commerce/php/development/security/content-security-policies/
https://developer.adobe.com/commerce/php/development/security/content-security-policies/#default-configuration

This is the specific fix: https://developer.adobe.com/commerce/php/development/security/content-security-policies/#inside-a-phtml-template

Though this fixes the inline JavaScript in this extension, it does not fix the downstream issue with the inline JavaScript tags returned from certexpress.com.